### PR TITLE
Fix unreachable commit

### DIFF
--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -35,7 +35,7 @@ fi
 # Download the orange pi firmware
 if [ ! -d firmware ]; then
     git clone --progress -b master https://github.com/orangepi-xunlong/firmware.git
-    git -C firmware checkout 88770e73b9a18ebe432c085f936ea7a4b447afde
+    git -C firmware checkout 79186949b2fbd01c52d55f085106b96dfd670ff6
 fi
 
 # These env vars can cause issues with chroot


### PR DESCRIPTION
The Git history from https://github.com/orangepi-xunlong/firmware.git was rewritten and the old commit [88770e73b9a18ebe432c085f936ea7a4b447afde](https://github.com/orangepi-xunlong/firmware/commit/88770e73b9a18ebe432c085f936ea7a4b447afde) no longer belongs to the `main` branch.

This resulted in the following error message:
```
fatal: reference is not a tree: 88770e73b9a18ebe432c085f936ea7a4b447afde
```

To fix this issue, I changed the commit to the latest available commit ([79186949b2fbd01c52d55f085106b96dfd670ff6](https://github.com/orangepi-xunlong/firmware/commit/79186949b2fbd01c52d55f085106b96dfd670ff6)). I guess this will not be the last time they rewrite the Git history. :wink: