### PR TITLE
Get rid of ridiculous compression

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -196,6 +196,6 @@ umount "${disk}${partition_char}2"
 losetup -d "${loop}"
 
 echo -e "\nCompressing $(basename "${img}.xz")\n"
-xz -9 --force --keep --quiet --threads=0 "${img}"
+xz -3 --force --keep --quiet --threads=0 "${img}"
 rm -f "${img}"
 cd ../images && sha256sum "$(basename "${img}.xz")" > "$(basename "${img}.xz.sha256")"


### PR DESCRIPTION
```
version     compression     size        time
desktop     -9              1319891116  7m44.285s
desktop     -6 (default)    1424438064  4m20.448s
desktop     -3              1566458080  2m19.042s
desktop     -1              1670375184  1m20.116s
```

The test results speak for themselves. High compression is just wasteful.
Tested on Xeon W-2145